### PR TITLE
Feature/stylus compiler options

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist test/temp",
-    "test": "ava test/styl/index.js test/stylus/index.js",
+    "test": "ava test/styl/index.js test/stylus/index.js test/compiler-options/index.js test/relative-path/index.js",
     "pretest": "npm run build",
     "build": "rollup -c -f cjs -o dist/rollup-plugin-stylus-compiler.cjs.js && rollup -c -f es -o dist/rollup-plugin-stylus-compiler.es.js",
     "prepublish": "npm test"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,6 @@ var external = Object.keys(require('./package.json').dependencies);
 
 export default {
   entry: 'src/index.js',
-  external: external,
+  external: external.concat(['path']),
   plugins: [buble()]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { createFilter } from 'rollup-pluginutils'
 import compiler from 'stylus'
+import path from 'path'
 
 const name = 'rollup-plugin-stylus-compiler'
 const debug = require('debug')(name)
@@ -44,7 +45,10 @@ export default function(options = {}) {
       debug('transform id=%s, code=%s', id, code)
       if (!filter(id)) return
       return new Promise(function(resolve, reject) {
-        compiler(code).render(function(err, css) {
+				const stylus = compiler(code, options.compiler);
+				const relativePath = path.relative(process.cwd(), id);
+				stylus.set('filename', relativePath);
+				stylus.render(function(err, css) {
           if (err) reject(err)
           else {
             // cache the compiled content

--- a/test/assets/variables.styl
+++ b/test/assets/variables.styl
@@ -1,0 +1,1 @@
+$external-padding = 10

--- a/test/compiler-options/index.js
+++ b/test/compiler-options/index.js
@@ -1,0 +1,40 @@
+import test from 'ava'
+import fsp from 'fs-promise'
+import path from 'path'
+import { rollup } from 'rollup'
+import cssPorter from 'rollup-plugin-css-porter'
+import stylus from '../../dist/rollup-plugin-stylus-compiler.cjs.js'
+
+process.chdir(__dirname)
+const testDir = path.resolve('../temp/compiler-options/')
+
+const paths = [
+  path.resolve('../')
+]
+
+test("compile and output to css file with external variable file", async t => {
+  const toDir = path.join(testDir, 'css-only')
+  await fsp.remove(toDir) // clean
+  const jsFile = path.join(toDir, 'main.js')
+  const cssFile = path.join(toDir, 'main.css')
+
+  const bundle = await rollup({
+    entry: 'main.js',
+    plugins: [
+      stylus({compiler: { paths }}),
+			cssPorter()
+    ]
+  })
+
+  await bundle.write({
+    format: 'es',
+    dest: jsFile
+  });
+
+  t.true(await fsp.exists(jsFile))
+
+  t.true(await fsp.exists(cssFile))
+  let content = await fsp.readFile(cssFile, { encoding: 'UTF-8' })
+  t.is('.styl {\n  padding: 10;\n}\n', content)
+
+});

--- a/test/compiler-options/main.js
+++ b/test/compiler-options/main.js
@@ -1,0 +1,1 @@
+import './style.styl';

--- a/test/compiler-options/style.styl
+++ b/test/compiler-options/style.styl
@@ -1,0 +1,4 @@
+@import "assets/variables"
+
+.styl
+  padding $external-padding

--- a/test/relative-path/index.js
+++ b/test/relative-path/index.js
@@ -1,0 +1,36 @@
+import test from 'ava'
+import fsp from 'fs-promise'
+import path from 'path'
+import { rollup } from 'rollup'
+import cssPorter from 'rollup-plugin-css-porter'
+import stylus from '../../dist/rollup-plugin-stylus-compiler.cjs.js'
+
+process.chdir(__dirname)
+const testDir = path.resolve('../temp/relative-path/')
+
+test("compile and output to css file with relative import", async t => {
+  const toDir = path.join(testDir, 'css-only')
+  await fsp.remove(toDir) // clean
+  const jsFile = path.join(toDir, 'main.js')
+  const cssFile = path.join(toDir, 'main.css')
+
+  const bundle = await rollup({
+    entry: 'main.js',
+    plugins: [
+      stylus(),
+			cssPorter()
+    ]
+  })
+
+  await bundle.write({
+    format: 'es',
+    dest: jsFile
+  });
+
+  t.true(await fsp.exists(jsFile))
+
+  t.true(await fsp.exists(cssFile))
+  let content = await fsp.readFile(cssFile, { encoding: 'UTF-8' })
+  t.is('.styl {\n  padding: 10;\n}\n', content)
+
+});

--- a/test/relative-path/main.js
+++ b/test/relative-path/main.js
@@ -1,0 +1,1 @@
+import './style.styl';

--- a/test/relative-path/style.styl
+++ b/test/relative-path/style.styl
@@ -1,0 +1,4 @@
+@import "../assets/variables"
+
+.styl
+  padding $external-padding


### PR DESCRIPTION
Pull request contains two changes:

1. Correctly resolving relative path, needed when import from other project directory is required:
@import "../../assets/css/variables"

2. Allow passing options to stylus compiler e.g. when there is a need to use variables from other libraries (like bootstrap-stylus) 
